### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/corralperez/4d567596-b504-45db-80b2-57df51f250fb/be02ebd4-678c-4c3d-84f5-c6befae2f9a8/_apis/work/boardbadge/b320e04c-cfbc-45cb-87b2-ac08d0cbcce5)](https://dev.azure.com/corralperez/4d567596-b504-45db-80b2-57df51f250fb/_boards/board/t/be02ebd4-678c-4c3d-84f5-c6befae2f9a8/Microsoft.RequirementCategory)
 # CryptoTracker.DotNetCore


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/corralperez/4d567596-b504-45db-80b2-57df51f250fb/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.